### PR TITLE
NRFX SPI SDHC fixes

### DIFF
--- a/drivers/spi/Kconfig.nrfx
+++ b/drivers/spi/Kconfig.nrfx
@@ -12,18 +12,20 @@ menuconfig SPI_NRFX
 
 if SPI_NRFX
 
-config SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58
+config NRF52832_SPIM_PAN58_WORKAROUND
 	depends on SOC_NRF52832
-	bool "Allow enabling the SPIM driver despite PAN 58"
+	bool "nRF52832 SPIM driver PAN 58 workaround"
 	help
-	  Allow enabling the nRF SPI Master with EasyDMA, despite
-	  Product Anomaly Notice 58 (SPIM: An additional byte is
-	  clocked out when RXD.MAXCNT == 1 and TXD.MAXCNT <= 1).
-	  Without this override, the SPI Master is only available
+	  Enables the workaround for the nRF52832 Product Anomaly Notice 58
+	  for all nRF SPI Masters with EasyDMA.
+	  (PAN58: An additional byte is clocked out when
+	  RXD.MAXCNT == 1 and TXD.MAXCNT <= 1).
+	  Without this workaround, the SPI Master is only available
 	  without EasyDMA. Note that the 'SPIM' and 'SPIS' drivers
-	  use EasyDMA, while the 'SPI' driver does not. Use this
-	  option ONLY if you are certain that transactions with
-	  RXD.MAXCNT == 1 and TXD.MAXCNT <= 1 will NOT be executed.
+	  use EasyDMA, while the 'SPI' driver does not.
+	  Caution: the PPI and GPIOTE channels chosen via
+	  SPIM_X_NRF52832_PAN58_PPI_CH and SPIM_X_NRF52832_PAN58_GPIOTE_CH
+	  in this workaround must be carefully considered per SPIM enabled.
 
 # In most Nordic SoCs, SPI and TWI peripherals with the same instance number
 # share certain resources and therefore cannot be used at the same time
@@ -46,10 +48,8 @@ config SPI_0_NRF_SPI
 
 config SPI_0_NRF_SPIM
 	bool "nRF SPIM 0"
-	# This driver is not available for nRF52832 because of Product Anomaly 58
-	# (SPIM: An additional byte is clocked out when RXD.MAXCNT == 1 and TXD.MAXCNT <= 1)
-	# Allow the 'EasyDMA' driver only if this automatic safety-disable is overridden
-	depends on HAS_HW_NRF_SPIM0 && (!SOC_NRF52832 || SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58)
+	# This driver requires a workaround for nRF52832 because of Product Anomaly 58
+	depends on HAS_HW_NRF_SPIM0 && (!SOC_NRF52832 || NRF52832_SPIM_PAN58_WORKAROUND)
 	select NRFX_SPIM0
 	help
 	  Enable nRF SPI Master with EasyDMA on port 0.
@@ -75,6 +75,26 @@ config SPI_0_NRF_ORC
 	  Over-read character. Character clocked out after an over-read
 	  of the transmit buffer.
 
+if (SPI_0_NRF_SPIM && NRF52832_SPIM_PAN58_WORKAROUND)
+
+config SPIM_0_NRF52832_PAN58_PPI_CH
+	int "SPIM 0 PAN58 workaround PPI channel to use"
+	default 17
+	range 0 19
+	help
+	  SPI 0 SPIM PPI channel to use for PAN58 workaround.
+	  CAUTION: ensure PPI channel has no other users.
+
+config SPIM_0_NRF52832_PAN58_GPIOTE_CH
+	int "SPIM 0 PAN58 workaround GPIOTE channel to use"
+	default 5
+	range 0 7
+	help
+	  SPI 0 SPIM GPIOTE channel to use for PAN58 workaround.
+	  CAUTION: ensure GPIOTE channel has no other users.
+
+endif # (SPI_0_NRF_SPIM && NRF52832_SPIM_PAN58_WORKAROUND)
+
 endif # SPI_0 && (SOC_NRF52810 || ...
 
 # In Nordic SoCs, SPI and TWI peripherals with the same instance number
@@ -95,10 +115,8 @@ config SPI_1_NRF_SPI
 
 config SPI_1_NRF_SPIM
 	bool "nRF SPIM 1"
-	# This driver is not available for nRF52832 because of Product Anomaly 58
-	# (SPIM: An additional byte is clocked out when RXD.MAXCNT == 1 and TXD.MAXCNT <= 1)
-	# Allow the 'EasyDMA' driver only if this automatic safety-disable is overridden
-	depends on HAS_HW_NRF_SPIM1 && (!SOC_NRF52832 || SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58)
+	# This driver requires a workaround for nRF52832 because of Product Anomaly 58
+	depends on HAS_HW_NRF_SPIM1 && (!SOC_NRF52832 || NRF52832_SPIM_PAN58_WORKAROUND)
 	select NRFX_SPIM1
 	help
 	  Enable nRF SPI Master with EasyDMA on port 1.
@@ -124,6 +142,25 @@ config SPI_1_NRF_ORC
 	  Over-read character. Character clocked out after an over-read
 	  of the transmit buffer.
 
+if (SPI_1_NRF_SPIM && NRF52832_SPIM_PAN58_WORKAROUND)
+
+config SPIM_1_NRF52832_PAN58_PPI_CH
+	int "SPIM 1 PAN58 workaround PPI channel to use"
+	default 18
+	range 0 19
+	help
+	  SPI 1 SPIM PPI channel to use for PAN58 workaround.
+	  CAUTION: ensure PPI channel has no other users.
+
+config SPIM_1_NRF52832_PAN58_GPIOTE_CH
+	int "SPIM 1 PAN58 workaround GPIOTE channel to use"
+	default 6
+	range 0 7
+	help
+	  SPI 1 SPIM GPIOTE channel to use for PAN58 workaround.
+	  CAUTION: ensure GPIOTE channel has no other users.
+
+endif # (SPI_1_NRF_SPIM && NRF52832_SPIM_PAN58_WORKAROUND)
 endif # SPI_1 && !I2C_1 && !(SOC_SERIES_NRF91X && UART_1_NRF_UARTE) && ...
 
 # In Nordic SoCs, SPI and TWI peripherals with the same instance number
@@ -144,10 +181,8 @@ config SPI_2_NRF_SPI
 
 config SPI_2_NRF_SPIM
 	bool "nRF SPIM 2"
-	# This driver is not available for nRF52832 because of Product Anomaly 58
-	# (SPIM: An additional byte is clocked out when RXD.MAXCNT == 1 and TXD.MAXCNT <= 1)
-	# Allow the 'EasyDMA' driver only if this automatic safety-disable is overridden
-	depends on HAS_HW_NRF_SPIM2 && (!SOC_NRF52832 || SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58)
+	# This driver requires a workaround for nRF52832 because of Product Anomaly 58
+	depends on HAS_HW_NRF_SPIM2 && (!SOC_NRF52832 || NRF52832_SPIM_PAN58_WORKAROUND)
 	select NRFX_SPIM2
 	help
 	  Enable nRF SPI Master with EasyDMA on port 2.
@@ -173,6 +208,25 @@ config SPI_2_NRF_ORC
 	  Over-read character. Character clocked out after an over-read
 	  of the transmit buffer.
 
+if (SPI_2_NRF_SPIM && NRF52832_SPIM_PAN58_WORKAROUND)
+
+config SPIM_2_NRF52832_PAN58_PPI_CH
+	int "SPIM 2 PAN58 workaround PPI channel to use"
+	default 19
+	range 0 19
+	help
+	  SPI 2 SPIM PPI channel to use for PAN58 workaround.
+	  CAUTION: ensure PPI channel has no other users.
+
+config SPIM_2_NRF52832_PAN58_GPIOTE_CH
+	int "SPIM 2 PAN58 workaround GPIOTE channel to use"
+	default 7
+	range 0 7
+	help
+	  SPI 2 SPIM GPIOTE channel to use for PAN58 workaround.
+	  CAUTION: ensure GPIOTE channel has no other users.
+
+endif # (SPI_2_NRF_SPIM && NRF52832_SPIM_PAN58_WORKAROUND)
 endif # SPI_2 && !I2C_2 && !(SOC_SERIES_NRF91X && UART_2_NRF_UARTE) && ...
 
 # In Nordic SoCs, SPI and TWI peripherals with the same instance number

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -356,7 +356,7 @@ static inline size_t spi_context_longest_current_buf(struct spi_context *ctx)
 		return ctx->rx_len;
 	} else if (!ctx->rx_len) {
 		return ctx->tx_len;
-	} else if (ctx->tx_len < ctx->rx_len) {
+	} else if (ctx->tx_len > ctx->rx_len) {
 		return ctx->tx_len;
 	}
 

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -459,7 +459,7 @@ static int spim_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 		))
 
 #ifdef CONFIG_NRF52832_SPIM_PAN58_WORKAROUND
-#define NRF52832_CONFIG_PAN58_WORKAROUND(idx)                        \
+#define NRF52832_CONFIG_PAN58_WORKAROUND(idx) ,                       \
 		.ppi_ch = CONFIG_SPIM_##idx##_NRF52832_PAN58_PPI_CH, \
 		.gpiote_ch = CONFIG_SPIM_##idx##_NRF52832_PAN58_GPIOTE_CH,
 #else

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(spi_nrfx_spim);
 
 #include "spi_context.h"
 
+
 struct spi_nrfx_data {
 	struct spi_context ctx;
 	size_t chunk_len;
@@ -28,9 +29,13 @@ struct spi_nrfx_data {
 };
 
 struct spi_nrfx_config {
-	nrfx_spim_t	   spim;
-	size_t		   max_chunk_len;
+	nrfx_spim_t        spim;
+	size_t             max_chunk_len;
 	nrfx_spim_config_t config;
+#ifdef CONFIG_NRF52832_SPIM_PAN58_WORKAROUND
+	u8_t               ppi_ch;
+	u8_t               gpiote_ch;
+#endif
 };
 
 static inline struct spi_nrfx_data *get_dev_data(struct device *dev)
@@ -149,6 +154,69 @@ static int configure(struct device *dev,
 	return 0;
 }
 
+#ifdef CONFIG_NRF52832_SPIM_PAN58_WORKAROUND
+/*
+ * brief Work-around for transmitting 1 byte with SPIM.
+ *
+ * param spim: The SPIM instance that is in use.
+ * param ppi_channel: An unused PPI channel that will be used by the
+ *                    workaround.
+ * param gpiote_channel: An unused GPIOTE channel that will be used by the
+ *                       workaround.
+ *
+ * warning Must not be used when transmitting multiple bytes.
+ *
+ * warning After this workaround is used, the user must reset the PPI
+ * channel and the GPIOTE channel before attempting to transmit multiple
+ * bytes.
+ */
+static void setup_workaround_for_ftpan_58(NRF_SPIM_Type *spim, u32_t ppi_ch,
+	u32_t gpiote_ch)
+{
+	if (NRF_GPIOTE->CONFIG[gpiote_ch] != 0) {
+		LOG_WRN("NRF_GPIOTE->CONFIG[gpiote_ch] should be zero");
+	}
+	if (NRF_PPI->CH[ppi_ch].EEP != 0) {
+		LOG_WRN("NRF_PPI->CH[ppi_ch].EEP should be zero");
+	}
+	if (NRF_PPI->CH[ppi_ch].TEP != 0) {
+		LOG_WRN("NRF_PPI->CH[ppi_ch].TEP should be zero");
+	}
+	if ((NRF_PPI->CHEN & (1U << ppi_ch)) != 0) {
+		LOG_WRN("(NRF_PPI->CHEN & (1U << ppi_ch)) should be zero");
+	}
+
+	/* Create an event when SCK toggles */
+	NRF_GPIOTE->CONFIG[gpiote_ch] =
+		(GPIOTE_CONFIG_MODE_Event << GPIOTE_CONFIG_MODE_Pos) |
+		(spim->PSEL.SCK << GPIOTE_CONFIG_PSEL_Pos) |
+		(GPIOTE_CONFIG_POLARITY_Toggle << GPIOTE_CONFIG_POLARITY_Pos);
+
+	/* Stop the spim instance when SCK toggles */
+	NRF_PPI->CH[ppi_ch].EEP = (u32_t)&NRF_GPIOTE->EVENTS_IN[gpiote_ch];
+	NRF_PPI->CH[ppi_ch].TEP = (u32_t)&spim->TASKS_STOP;
+	NRF_PPI->CHENSET = 1U << ppi_ch;
+
+	/* The spim instance cannot be stopped mid-byte, so it will finish
+	 * transmitting the first byte and then stop. Effectively ensuring
+	 * that only 1 byte is transmitted.
+	 */
+}
+
+static void clear_workaround_for_ftpan_58(NRF_SPIM_Type *spim, u32_t ppi_ch,
+	u32_t gpiote_ch)
+{
+	NRF_PPI->CHENCLR = 1U << ppi_ch;
+
+	/* Disable SCK toggles event */
+	NRF_GPIOTE->CONFIG[gpiote_ch] = 0;
+
+	/* Clear Event and Task End Points */
+	NRF_PPI->CH[ppi_ch].EEP = 0;
+	NRF_PPI->CH[ppi_ch].TEP = 0;
+}
+#endif
+
 static void transfer_next_chunk(struct device *dev)
 {
 	struct spi_nrfx_data *dev_data = get_dev_data(dev);
@@ -183,21 +251,27 @@ static void transfer_next_chunk(struct device *dev)
 		xfer.p_rx_buffer = ctx->rx_buf;
 		xfer.rx_length   = spi_context_rx_buf_on(ctx) ? chunk_len : 0;
 
-		/* This SPIM driver is only used by the NRF52832 if
-		   SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58 is enabled */
-		if (IS_ENABLED(CONFIG_SOC_NRF52832) &&
-		   (xfer.rx_length == 1 && xfer.tx_length <= 1)) {
-			LOG_WRN("Transaction aborted since it would trigger nRF52832 PAN 58");
-			error = -EIO;
-		}
-
-		if (!error) {
+#ifdef CONFIG_NRF52832_SPIM_PAN58_WORKAROUND
+		if ((xfer.rx_length == 1 && xfer.tx_length <= 1)) {
+			setup_workaround_for_ftpan_58(
+				dev_config->spim.p_reg,
+				dev_config->ppi_ch,
+				dev_config->gpiote_ch);
 			result = nrfx_spim_xfer(&dev_config->spim, &xfer, 0);
-			if (result == NRFX_SUCCESS) {
-				return;
-			}
-			error = -EIO;
+			clear_workaround_for_ftpan_58(
+				dev_config->spim.p_reg,
+				dev_config->ppi_ch,
+				dev_config->gpiote_ch);
+		} else {
+			result = nrfx_spim_xfer(&dev_config->spim, &xfer, 0);
 		}
+#else
+		result = nrfx_spim_xfer(&dev_config->spim, &xfer, 0);
+#endif
+		if (result == NRFX_SUCCESS) {
+			return;
+		}
+		error = -EIO;
 	}
 
 	spi_context_cs_control(ctx, false);
@@ -384,6 +458,14 @@ static int spim_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 			(.rx_delay = CONFIG_SPI_##idx##_NRF_RX_DELAY,))	\
 		))
 
+#ifdef CONFIG_NRF52832_SPIM_PAN58_WORKAROUND
+#define NRF52832_CONFIG_PAN58_WORKAROUND(idx)                        \
+		.ppi_ch = CONFIG_SPIM_##idx##_NRF52832_PAN58_PPI_CH, \
+		.gpiote_ch = CONFIG_SPIM_##idx##_NRF52832_PAN58_GPIOTE_CH,
+#else
+#define NRF52832_CONFIG_PAN58_WORKAROUND(idx)
+#endif
+
 #define SPI_NRFX_SPIM_DEVICE(idx)					       \
 	BUILD_ASSERT_MSG(						       \
 		!SPIM_NRFX_MISO_PULL_UP(idx) || !SPIM_NRFX_MISO_PULL_DOWN(idx),\
@@ -416,6 +498,7 @@ static int spim_nrfx_pm_control(struct device *dev, u32_t ctrl_command,
 			.miso_pull = SPIM_NRFX_MISO_PULL(idx),		       \
 			SPI_NRFX_SPIM_EXTENDED_CONFIG(idx)		       \
 		}							       \
+		NRF52832_CONFIG_PAN58_WORKAROUND(idx)                          \
 	};								       \
 	DEVICE_DEFINE(spi_##idx,					       \
 		      DT_NORDIC_NRF_SPIM_SPI_##idx##_LABEL,		       \

--- a/soc/arm/nordic_nrf/nrf52/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/nrf52/CMakeLists.txt
@@ -14,11 +14,3 @@ zephyr_library_include_directories(
   ${ZEPHYR_BASE}/kernel/include
   ${ZEPHYR_BASE}/arch/arm/include
   )
-
-if(CONFIG_SOC_NRF52832)
-  if(CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58)
-    if(CONFIG_SPI_0_NRF_SPIM OR CONFIG_SPI_1_NRF_SPIM OR CONFIG_SPI_2_NRF_SPIM)
-      message(WARNING "Both SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58 and an NRF SPIM driver are enabled, therefore PAN 58 will apply if RXD.MAXCNT == 1 and TXD.MAXCNT <= 1")
-    endif()
-  endif()
-endif()

--- a/subsys/disk/disk_access_spi_sdhc.c
+++ b/subsys/disk/disk_access_spi_sdhc.c
@@ -764,6 +764,7 @@ static int disk_spi_sdhc_init(struct device *dev);
 
 static int sdhc_spi_init(struct device *dev)
 {
+	static struct spi_cs_control spi_cs_control_0;
 	struct sdhc_spi_data *data = dev->driver_data;
 
 	data->spi = device_get_binding(DT_INST_0_ZEPHYR_MMC_SPI_SLOT_BUS_NAME);
@@ -777,6 +778,11 @@ static int sdhc_spi_init(struct device *dev)
 
 	data->pin = DT_INST_0_ZEPHYR_MMC_SPI_SLOT_CS_GPIOS_PIN;
 	data->flags = DT_INST_0_ZEPHYR_MMC_SPI_SLOT_CS_GPIOS_FLAGS;
+
+	spi_cs_control_0.gpio_dev = data->cs;
+	spi_cs_control_0.gpio_pin = data->pin;
+	spi_cs_control_0.delay = 10;
+	data->cfg.cs = &spi_cs_control_0;
 
 	disk_spi_sdhc_init(dev);
 


### PR DESCRIPTION
- Use Nordic workaround for PAN58 (NRFX SPIM driver) to cope with single byte reads used by disk access driver
- Fix a missing CS control initialization in Disk Access SPI SDHC