### PR TITLE
Increase SDHC Ready Timeout to 2s.

### DIFF
--- a/subsys/disk/disk_access_sdhc.h
+++ b/subsys/disk/disk_access_sdhc.h
@@ -103,7 +103,7 @@ enum sdhc_app_ext_cmd {
 /* Time to wait for the card to initialise */
 #define SDHC_INIT_TIMEOUT K_MSEC(5000)
 /* Time to wait for the card to respond or come ready */
-#define SDHC_READY_TIMEOUT K_MSEC(500)
+#define SDHC_READY_TIMEOUT K_MSEC(2000)
 
 enum sdhc_rsp_type {
 	SDHC_RSP_TYPE_NONE = 0U,


### PR DESCRIPTION
With the testing card I had, it happened that consecutive file operations pulled the write time way above 1s. 2s timeout was enough to contain any test run.

Note: Whilst the testing card is a class 10 Kingston SDHC card, the operations on the card involved consecutive single block writes rather than a long stream. I guess that's the reason why the card performed so poorly at the end.