### PR TITLE
Make use of external timestamps configurable.

### DIFF
--- a/subsys/logging/Kconfig
+++ b/subsys/logging/Kconfig
@@ -104,6 +104,11 @@ config LOG_FUNC_NAME_PREFIX_DBG
 
 endmenu
 
+config LOG_EXTERNAL_TIMESTAMPS
+	bool "Use external timestamp implementation"
+	help
+		Use external timestamp functions.
+
 config LOG_PRINTK
 	bool "Enable processing of printk messages."
 	help

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -42,8 +42,7 @@ static const char *const colors[] = {
 };
 
 //MR
-#define ZB_LOGGING
-#ifndef ZB_LOGGING
+#ifndef LOG_CONFIG_EXTERNAL_TIMESTAMPS
 static u32_t freq;
 #else
 u32_t freq;
@@ -129,7 +128,7 @@ static int out_func(int c, void *ctx)
 }
 
 //MR
-#ifndef ZB_LOGGING
+#ifndef LOG_CONFIG_EXTERNAL_TIMESTAMPS
 static int print_formatted(const struct log_output *log_output,
 #else
 int print_formatted(const struct log_output *log_output,
@@ -174,7 +173,7 @@ void log_output_flush(const struct log_output *log_output)
 }
 
 //MR
-#ifndef ZB_LOGGING
+#ifndef LOG_CONFIG_EXTERNAL_TIMESTAMPS
 static int timestamp_print(const struct log_output *log_output,
 			   u32_t flags, u32_t timestamp)
 {


### PR DESCRIPTION
I had to make this configurable, so that we can compile projects that do not provide external implementation (mcuboot).