### PR TITLE
Make std_print and hexdump_print public.

### DIFF
--- a/include/logging/log_output.h
+++ b/include/logging/log_output.h
@@ -188,6 +188,13 @@ static inline void log_output_hostname_set(const struct log_output *log_output,
  */
 void log_output_timestamp_freq_set(u32_t freq);
 
+void hexdump_print(struct log_msg *msg,
+			  const struct log_output *log_output,
+			  int prefix_offset, u32_t flags);
+
+void std_print(struct log_msg *msg,
+		      const struct log_output *log_output);
+
 /**
  * @}
  */

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -297,7 +297,7 @@ static void newline_print(const struct log_output *ctx, u32_t flags)
 	}
 }
 
-static void std_print(struct log_msg *msg,
+void std_print(struct log_msg *msg,
 		      const struct log_output *log_output)
 {
 	const char *str = log_msg_str_get(msg);
@@ -426,7 +426,7 @@ static void hexdump_line_print(const struct log_output *log_output,
 	}
 }
 
-static void hexdump_print(struct log_msg *msg,
+void hexdump_print(struct log_msg *msg,
 			  const struct log_output *log_output,
 			  int prefix_offset, u32_t flags)
 {


### PR DESCRIPTION
This is to simplify development of https://github.com/cloudfieldcz/zetbox/pull/111